### PR TITLE
Prototype2 HUD: live sentiment, refs [1],[2],[3], tooltips, gateway wiring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ data/*.bin
 data/*.pkl
 data/*.bin
 data/*.pk.
+frontend/.env

--- a/frontend/src/renderer/index.html
+++ b/frontend/src/renderer/index.html
@@ -62,7 +62,9 @@
 
       <!-- Sentiment -->
       <div class="sec sentiment">
-        <span class="label" data-tooltip="<strong>Sentiment</strong><br>FinBERT news tone (FR-3).">Sent</span>
+        <span class="label" data-tooltip="<strong>Sentiment</strong><br>FinBERT news tone (FR-3).
+                      <br><u>Sentiment Score: </u>positive = bullish lean, negative = earish
+                      <br><u>Sentiment Volatility (σ): </u> standard deviation of sentiment over time, how volatile or stable sentiment has been.">Sent</span>
         <span class="val" id="sent">—</span>
         <span class="sigma" id="sigma">σ—</span>
       </div>
@@ -70,7 +72,12 @@
 
       <!-- Strategy -->
       <div class="sec strat"
-           data-tooltip="<strong>Strategy Suggestion</strong><br>Class + model confidence.">
+           data-tooltip="<strong>Strategy Suggestion</strong><br>Class + model confidence.
+                      <br><u>No Action (Passive): </u>Hold your position, with no trades.
+                      <br><u>Iron Condor (Neutral, Low Volatility): </u>Gain profit if the price stays in a set range.
+                      <br><u>Debit Call Spread: </u>Bullish (optimistic) bet on a moderate rise. 
+                      <br><u>Debit Put Spread: </u>Bearish (pessimistic) bet on a moderate drop.
+                      <br><u>Covered Call: </u>Earn income by selling (writing) a call option on shares you own. ">
         <span class="badge" id="strat">NA</span>
         <span class="conf"><span class="bar" id="bar"></span><span id="conf">—</span></span>
       </div>

--- a/frontend/src/renderer/renderer.js
+++ b/frontend/src/renderer/renderer.js
@@ -1,24 +1,35 @@
-// renderer.js — HUD (Windows copy) with HEADLINE-as-link + word-boundary clamp
+// renderer.js — HUD (Windows copy) with LLM one-liner + [1][2][3] refs + rich tooltips
+console.log(">>> HUD renderer loaded from src/renderer/renderer.js");
 
 // ---------- helpers ----------
 function $(id) { return document.getElementById(id); }
 function signClass(n) { if (n > 0) return "pos"; if (n < 0) return "neg"; return "neu"; }
-function escapeHtml(s) { return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;"); }
-function fmtPct(x, dp=2) { return `${(x*100).toFixed(dp)}%`; }
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g,"&amp;")
+    .replace(/</g,"&lt;")
+    .replace(/>/g,"&gt;");
+}
+function fmtPct(x, dp = 2) {
+  return `${(x * 100).toFixed(dp)}%`;
+}
 
 // Remove "<CLASS>:" prefix & "Conf XX%" then tidy spacing
-function stripClassAndConf(text, klass){
+function stripClassAndConf(text, klass) {
   if (!text) return "—";
   let t = String(text);
   if (klass) {
-    const rePrefix = new RegExp("^\\s*" + klass.replace(/[-/\\^$*+?.()|[\\]{}]/g,"\\$&") + "\\s*:\\s*", "i");
+    const rePrefix = new RegExp(
+      "^\\s*" + klass.replace(/[-/\\^$*+?.()|[\\]{}]/g, "\\$&") + "\\s*:\\s*",
+      "i"
+    );
     t = t.replace(rePrefix, "");
   }
   t = t.replace(/\bConf\s+\d{1,3}%\.?/i, "");
   t = t.replace(/\s{2,}/g, " ").replace(/\s+([.,;:!?])/g, "$1").trim();
   return t || "—";
 }
-function capitalizeFirstWord(s){
+function capitalizeFirstWord(s) {
   if (!s) return s;
   const i = s.search(/[A-Za-z]/);
   if (i < 0) return s;
@@ -26,35 +37,39 @@ function capitalizeFirstWord(s){
 }
 
 // Clamp span/anchor text at a word boundary to fit `maxPx`
-function truncateAtWord(el, fullText, maxPx){
+function truncateAtWord(el, fullText, maxPx) {
   el.textContent = fullText;
   if (el.scrollWidth <= maxPx) return;
 
   let lo = 0, hi = fullText.length, best = "…";
-  while (lo < hi){
-    const mid = (lo + hi) >> 1;
+  while (lo < hi) {
+    const mid   = (lo + hi) >> 1;
     const slice = fullText.slice(0, mid);
     const cut   = slice.lastIndexOf(" ");
     const cand  = (cut > 0 ? slice.slice(0, cut) : slice).trimEnd() + "…";
     el.textContent = cand;
-    if (el.scrollWidth <= maxPx){ best = cand; lo = mid + 1; }
-    else { hi = mid; }
+    if (el.scrollWidth <= maxPx) {
+      best = cand;
+      lo   = mid + 1;
+    } else {
+      hi = mid;
+    }
   }
   el.textContent = best;
 }
 
-// Re-clamp only the HEADLINE (now the link itself) based on available width
-function clampHeadline(){
+// Re-clamp only the HEADLINE (now the LLM text span) based on available width
+function clampHeadline() {
   const line = el.one;
   if (!line) return;
 
   const prefix   = line.querySelector(".one-prefix");
-  const headline = line.querySelector(".one-headline"); // <a> if link, <span> if no link
+  const headline = line.querySelector(".one-headline"); // span
   if (!headline) return;
 
   const boxW  = line.clientWidth || 0;
   const prefW = prefix ? prefix.getBoundingClientRect().width : 0;
-  const gap   = 0;  // no separate link anymore
+  const gap   = 0;
 
   const maxPx = Math.max(0, Math.floor(boxW - prefW - gap));
   if (maxPx <= 0) return;
@@ -63,7 +78,17 @@ function clampHeadline(){
   truncateAtWord(headline, full, maxPx);
 }
 
-// ---------- DOM refs ----------
+// small helper for tooltips
+function setTooltip(elm, html) {
+  if (!elm) return;
+  if (html == null || html === "") {
+    elm.removeAttribute("data-tooltip");
+  } else {
+    elm.setAttribute("data-tooltip", html);
+  }
+}
+
+// ---------- DOM refs (containers) ----------
 const el = {
   ticker: $("ticker"),
   last: $("last"),
@@ -71,8 +96,8 @@ const el = {
   m1: $("m1"),
   m5: $("m5"),
   sma: $("sma"),
-  sent: $("sent"),
-  sigma: $("sigma"),
+  sent: $("sentWrap") || $("sent"), // container that holds Sent/σ
+  sigma: $("sigmaVal") || $("sigma"), // support both ids
   strat: $("strat"),
   bar: $("bar"),
   conf: $("conf"),
@@ -82,131 +107,270 @@ const el = {
   validationPrompt: $("validationPrompt"),
 };
 
+// ---------- value spans (actual text nodes) ----------
+const elVals = {
+  // these ids come directly from your index.html
+  last: $("last"),
+  ba: $("ba"),
+  m1: $("m1"),
+  m5: $("m5"),
+  sma: $("sma"),
+  sent: $("sent"),
+  sigma: $("sigma"),
+  oneBox: $("one"),
+  cache: $("cache"),
+};
+
 // ---------- config ----------
 const GATEWAY_URL = "http://127.0.0.1:8015";
 let currentTicker = null;
 let isFetching = false;
+let cacheTimer = null;
+let cacheBaseAge = 0;
+let caseStartMS = 0;
+
+const STRAT_TOOLTIPS = {
+  NO_ACTION:
+    "<strong>No Action</strong><br>Model sees no clear edge. News and price action are mixed or weak; sitting out may be safest.",
+  IRON_CONDOR:
+    "<strong>Iron Condor</strong><br>Range-bound / IV watch. Model thinks price is likely to chop sideways; sell premium around the current level.",
+  DEBIT_CALL:
+    "<strong>Debit Call</strong><br>Directional bullish. Model sees upward edge with limited risk via a call or call spread.",
+  DEBIT_PUT:
+    "<strong>Debit Put</strong><br>Directional bearish. Model sees downward edge with limited risk via a put or put spread.",
+  COVERED_CALL:
+    "<strong>Covered Call</strong><br>Moderately bullish / income. Own shares and sell calls to harvest premium while expecting mild upside or flat price."
+};
 
 // ---------- validation ----------
-function formatAndValidateTicker(raw){
+function formatAndValidateTicker(raw) {
   const t = (raw || "").trim().toUpperCase();
-  if (!t) return { ok:false, msg:"Please enter a ticker" };
-  if (!/^[A-Z]{1,5}$/.test(t)) return { ok:false, msg:"*Invalid ticker format. Use letters only (1-5 characters, e.g., AAPL)." };
-  return { ok:true, ticker:t };
+  if (!t) return { ok: false, msg: "Please enter a ticker" };
+  if (!/^[A-Z]{1,5}$/.test(t)) {
+    return {
+      ok: false,
+      msg: "*Invalid ticker format. Use letters only (1-5 characters, e.g., AAPL).",
+    };
+  }
+  return { ok: true, ticker: t };
 }
-function showValidationMessage(message, isError = true){
+function showValidationMessage(message, isError = true) {
   el.validationPrompt.textContent = message;
   el.validationPrompt.classList.remove("neutral");
   el.validationPrompt.style.color = isError ? "#FF5F57" : "#AAA";
   el.validationPrompt.classList.remove("hidden");
 }
-function clearValidationMessage(){
+function clearValidationMessage() {
   el.validationPrompt.textContent = "";
   el.validationPrompt.classList.remove("neutral");
   el.validationPrompt.classList.add("hidden");
 }
 
 // ---------- networking ----------
-async function fetchRun(ticker){
-  const res = await fetch(`${GATEWAY_URL}/api/run?ticker=${encodeURIComponent(ticker)}`, { cache: "no-store" });
+async function fetchRun(ticker) {
+  const res = await fetch(
+    `${GATEWAY_URL}/api/run?ticker=${encodeURIComponent(ticker)}`,
+    { cache: "no-store" }
+  );
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   return res.json();
 }
 
 // ---------- HUD helpers ----------
-function clearHud(){
-  [["last","—"],["ba","B/A"],["m1","—"],["m5","—"],["sma","SMA20"],
-   ["sent","—"],["sigma","σ—"],["strat","NA"],["conf","—"],["one","Loading…"],["cache","⟳—s"]]
-    .forEach(([k,v])=>{ if(el[k]) el[k].textContent=v; });
-  if(el.bar) el.bar.style.width="0px";
+function clearHud() {
+  elVals.last.textContent   = "—";
+  elVals.ba.textContent     = "B/A";
+  elVals.m1.textContent     = "—";
+  elVals.m5.textContent     = "—";
+  elVals.sma.textContent    = "SMA20";
+  elVals.sent.textContent   = "—";
+  elVals.sigma.textContent  = "σ—";
+  elVals.oneBox.textContent = "Loading…";
+  elVals.cache.textContent  = "⟳—s";
+
+  if (el.bar) el.bar.style.width = "0px";
   el.hudInfo.classList.remove("active");
   el.hudInfo.classList.add("hidden");
 }
 
-function render(payload){
+function render(payload) {
   const f    = payload?.features || {};
   const rec  = payload?.recommendation || {};
-  const line = payload?.one_liner?.text || "—";
-  const head = payload?.top_headline;
+  const one  = payload?.one_liner || {};
   const q    = payload?.quote || null;
   const age  = payload?.cache_age_seconds;
 
   // Last / B&A
-  if (q && typeof q.last === "number" && isFinite(q.last) && q.last > 0) el.last.textContent = q.last.toFixed(2);
-  else el.last.textContent = "—";
-  if (q && q.bid!=null && q.ask!=null && isFinite(q.bid) && isFinite(q.ask) && q.ask>q.bid)
-    el.ba.textContent = `${Number(q.bid).toFixed(2)}/${Number(q.ask).toFixed(2)}`;
-  else el.ba.textContent = "B/A";
+  if (q && typeof q.last === "number" && isFinite(q.last) && q.last > 0) {
+    elVals.last.textContent = q.last.toFixed(2);
+  } else {
+    elVals.last.textContent = "—";
+  }
+
+  if (
+    q &&
+    q.bid != null &&
+    q.ask != null &&
+    isFinite(q.bid) &&
+    isFinite(q.ask) &&
+    q.ask > q.bid
+  ) {
+    elVals.ba.textContent = `${Number(q.bid).toFixed(2)}/${Number(q.ask).toFixed(2)}`;
+  } else {
+    elVals.ba.textContent = "B/A";
+  }
 
   // Returns
-  const r1 = (typeof f.r_1m === "number") ? f.r_1m : null;
-  const r5 = (typeof f.r_5m === "number") ? f.r_5m : null;
-  el.m1.textContent = r1 == null ? "—" : `1m ${(r1 >= 0 ? "+" : "")}${fmtPct(r1)}`;
-  el.m1.className   = `sec num ${signClass(r1 ?? 0)}`;
-  el.m5.textContent = r5 == null ? "—" : `5m ${(r5 >= 0 ? "+" : "")}${fmtPct(r5)}`;
-  el.m5.className   = `sec num ${signClass(r5 ?? 0)}`;
+  const r1 = typeof f.r_1m === "number" ? f.r_1m : null;
+  const r5 = typeof f.r_5m === "number" ? f.r_5m : null;
+  elVals.m1.textContent =
+    r1 == null ? "—" : `1m ${(r1 >= 0 ? "+" : "")}${fmtPct(r1)}`;
+  elVals.m5.textContent =
+    r5 == null ? "—" : `5m ${(r5 >= 0 ? "+" : "")}${fmtPct(r5)}`;
+  el.m1.className = `sec num ${signClass(r1 ?? 0)}`;
+  el.m5.className = `sec num ${signClass(r5 ?? 0)}`;
 
   // SMA20
   const above = !!f.above_sma20;
-  el.sma.textContent = above ? "↑" : "↓";
-  el.sma.className   = `sec muted ${above ? "pos" : "neg"}`;
+  elVals.sma.textContent = above ? "↑" : "↓";
+  $("sma").className = `sec muted ${above ? "pos" : "neg"}`;
 
   // Sentiment
-  const sMean = (typeof f.sent_mean === "number") ? f.sent_mean : null;
-  const sStd  = (typeof f.sent_std  === "number") ? f.sent_std  : null;
-  el.sent.textContent  = sMean==null ? "—" : `${sMean>=0?"+":""}${sMean.toFixed(2)}`;
-  el.sent.className    = sMean==null ? "val neu" : `val ${signClass(sMean)}`;
-  el.sigma.textContent = sStd==null ? "σ—" : `σ${sStd.toFixed(2)}`;
+  const sMean = typeof f.sent_mean === "number" ? f.sent_mean : null;
+  const sStd  = typeof f.sent_std  === "number" ? f.sent_std  : null;
+  elVals.sent.textContent  =
+    sMean == null ? "—" : `${sMean >= 0 ? "+" : ""}${sMean.toFixed(2)}`;
+  elVals.sigma.textContent =
+    sStd == null ? "σ—" : `σ${sStd.toFixed(2)}`;
+
+  // Sentiment tooltips
+  const sentTip =
+    "<strong>Sentiment</strong><br>" +
+    "Mean news tone from recent headlines. Positive = bullish, negative = bearish. " +
+    "Computed from FinBERT-style scores on top stories.";
+  const sigmaTip =
+    "<strong>Sentiment σ</strong><br>" +
+    "Spread of news tone scores. High σ = disagreement across headlines; low σ = consensus. " +
+    "Large σ often pushes the model toward NO_ACTION or range-bound stances.";
+  setTooltip(el.sent, sentTip);
+  setTooltip(el.sigma, sigmaTip);
 
   // Strategy badge + confidence
   const klass   = rec.class || "NA";
-  const confPct = Math.round(((rec.confidence ?? 0) * 100));
-  el.strat.textContent = klass;
+  const confPct = Math.round((rec.confidence ?? 0) * 100);
+  el.strat.textContent = klass; // badge text
   el.bar.style.width   = `${Math.max(0, Math.min(100, confPct)) * 0.8}px`;
   el.conf.textContent  = Number.isFinite(confPct) ? `${confPct}%` : "—";
 
-  // ----- One-liner pieces -----
-  // Clean/Capitalise base sentence
-  let cleaned = stripClassAndConf(line, klass);
-  cleaned = capitalizeFirstWord(cleaned);
+  // Strategy tooltips
+  const stratBody = STRAT_TOOLTIPS[klass] ||
+    "<strong>Strategy</strong><br>Model’s recommended posture based on short-term price action, trend, volatility, liquidity, and news tone.";
+  setTooltip(el.strat, stratBody);
 
-  // Prefix text (up to "Source:") + Publisher
-  let prefixText = cleaned;
-  if (cleaned.toLowerCase().includes("source:")) {
-    prefixText = cleaned.split(/source:/i)[0].trim();
+  const confBody = Number.isFinite(confPct)
+    ? "<strong>Confidence</strong><br>" +
+      `Calibrated probability for the chosen strategy (~${confPct}%). ` +
+      "For example, 70% means about 7 of 10 similar setups historically matched this outcome."
+    : "<strong>Confidence</strong><br>Calibration not available for this prediction.";
+  setTooltip(el.conf, confBody);
+
+  // ----- One-liner pieces (LLM text only + [1][2][3]) -----
+  const rawLine   = one.text || "—";
+  // Strip trailing "([1][2][3])" cluster if present
+  const noRefsRaw = rawLine.replace(/\s*\(\[\d\]\[\d\]\[\d\]\)\s*$/, "");
+  let cleaned     = stripClassAndConf(noRefsRaw, klass);
+  cleaned         = capitalizeFirstWord(cleaned);
+  const display   = cleaned || "—";
+
+  // Build prefix + LLM line into #oneBox (prefix kept empty for clampHeadline)
+  elVals.oneBox.innerHTML =
+    `<span class="one-prefix"></span>` +
+    `<span class="one-headline" data-full="${escapeHtml(display)}">` +
+    `${escapeHtml(display)}</span>`;
+
+  // Append [1][2][3] indices from one_liner.refs_numbers
+  const refsNums = Array.isArray(one.refs_numbers) ? one.refs_numbers : [];
+  if (refsNums.length) {
+    const refsSpan = document.createElement("span");
+    refsSpan.className = "one-refs";
+    refsSpan.style.marginLeft = "4px";
+
+    refsNums.forEach((ref, idx) => {
+      if (!ref || !ref.n) return;
+      const a = document.createElement("a");
+      a.href = "#";
+      a.textContent = `[${ref.n}]`;
+      a.className = "src-link";
+      if (ref.url) {
+        a.setAttribute("data-external", ref.url);
+      }
+
+      if (idx === 0) {
+        refsSpan.appendChild(document.createTextNode(" "));
+      } else {
+        refsSpan.appendChild(document.createTextNode(", "));
+      }
+      refsSpan.appendChild(a);
+    });
+
+    refsSpan.appendChild(document.createTextNode(""));
+    elVals.oneBox.appendChild(refsSpan);
   }
-  const publisher = (head?.publisher || "").trim();
-  const headlineTitle = (head?.title || "").trim();
-  const prefixHtml =
-    escapeHtml(prefixText ? `${prefixText}. ` : "") +
-    (publisher ? `Source: ${escapeHtml(publisher)} — ` : "Source: ");
 
-  // Build: prefix (plain) + headline (link or span)
-  if (head?.url) {
-    el.one.innerHTML =
-      `<span class="one-prefix">${prefixHtml}</span>` +
-      `<a href="#" data-external="${escapeHtml(head.url)}" class="one-headline src-link" data-full="${escapeHtml(headlineTitle)}">${escapeHtml(headlineTitle)}</a>`;
-  } else {
-    el.one.innerHTML =
-      `<span class="one-prefix">${prefixHtml}</span>` +
-      `<span class="one-headline" data-full="${escapeHtml(headlineTitle)}">${escapeHtml(headlineTitle || cleaned)}</span>`;
-  }
+  // One-liner tooltip
+  const oneTip =
+    "<strong>One-line summary</strong><br>" +
+    "Compact LLM summary of price action, volatility, trend, sentiment and risk posture. " +
+    "Indices [1][2][3] jump to the specific headlines that informed this view.";
+  setTooltip(el.one, oneTip);
 
-  // Click-through for the HEADLINE (link)
+  // Click-through for index links (any anchor with data-external)
   if (!el.one._wired) {
     el.one.addEventListener("click", (ev) => {
-      const a = ev.target.closest('a[data-external]');
+      const a = ev.target.closest("a[data-external]");
       if (!a) return;
       ev.preventDefault();
       const href = a.getAttribute("data-external");
-      if (href) window.electronAPI?.openExternal(href);
+      if (href) {
+        if (window.electronAPI?.openExternal) {
+          window.electronAPI.openExternal(href);
+        } else {
+          window.open(href, "_blank");
+        }
+      }
     });
     el.one._wired = true;
   }
 
-  // Cache age
-  el.cache.textContent = (typeof age === "number" && age >= 0) ? `⟳${age}s` : "⟳—s";
+  // Cache age: live "data staleness" counter
+  if (typeof age === "number" && age >= 0) {
+    cacheBaseAge = age;
+    cacheStartMs = Date.now();
 
+    if (cacheTimer) clearInterval(cacheTimer);
+
+    const updateCache = () => {
+      const dt = Math.floor((Date.now() - cacheStartMs) / 1000);
+      const val = Math.max(0, cacheBaseAge + dt);
+      elVals.cache.textContent = `⟳${val}s`;
+    };
+
+    updateCache();
+    cacheTimer = setInterval(updateCache, 1000);
+  } else {
+    if (cacheTimer) { clearInterval(cacheTimer); cacheTimer = null; }
+    cacheBaseAge = 0;
+    cacheStartMs = 0;
+    elVals.cache.textContent = "⟳—s";
+  }
+
+  setTooltip(
+    el.cache,
+    "<strong>Refresh Age</strong><br>" +
+    "Approximate time since this snapshot was computed on the backend. " +
+    "Counts up until you refresh the ticker."
+  );
+  
   // Show HUD row then clamp HEADLINE only
   el.hudInfo.classList.remove("hidden");
   el.hudInfo.classList.add("active");
@@ -214,7 +378,7 @@ function render(payload){
 }
 
 // ---------- main handler ----------
-async function handleEnter(){
+async function handleEnter() {
   const v = formatAndValidateTicker(el.ticker.textContent);
 
   if (!v.ok) {
@@ -238,7 +402,10 @@ async function handleEnter(){
     render(payload);
   } catch (err) {
     console.error(err);
-    showValidationMessage("*Unable to fetch data. Is the gateway running on 8015?", true);
+    showValidationMessage(
+      "*Unable to fetch data. Is the gateway running on 8015?",
+      true
+    );
     clearHud();
     currentTicker = null;
   } finally {
@@ -248,28 +415,34 @@ async function handleEnter(){
 
 // ---------- boot ----------
 document.addEventListener("DOMContentLoaded", () => {
-  el.validationPrompt.textContent = "Welcome to MIDAS! Enter a ticker symbol to begin.";
+  el.validationPrompt.textContent =
+    "Welcome to MIDAS! Enter a ticker symbol to begin.";
   el.validationPrompt.classList.add("neutral");
 
   el.ticker.addEventListener("keydown", (ev) => {
-    if (ev.key === "Enter") { ev.preventDefault(); handleEnter(); }
+    if (ev.key === "Enter") {
+      ev.preventDefault();
+      handleEnter();
+    }
   });
 
   // Re-clamp headline when window width changes
-  window.addEventListener("resize", () => requestAnimationFrame(clampHeadline));
+  window.addEventListener("resize", () =>
+    requestAnimationFrame(clampHeadline)
+  );
 });
 
-// ---------- Tooltip hover handler (3-second delay) ----------
+// ---------- Tooltip hover handler ----------
 const tooltip = $("tooltip");
 let tooltipTimer = null;
 
 document.body.addEventListener("mouseover", (ev) => {
+  if (!tooltip) return;  // guard for missing tooltip element
   const target = ev.target.closest("[data-tooltip]");
   if (!target) return;
   const text = target.getAttribute("data-tooltip");
   if (!text) return;
 
-  // Start a timer — show tooltip only after 3 seconds of hover
   tooltipTimer = setTimeout(() => {
     tooltip.innerHTML = text;
     tooltip.style.opacity = "1";
@@ -278,14 +451,30 @@ document.body.addEventListener("mouseover", (ev) => {
 });
 
 document.body.addEventListener("mousemove", (ev) => {
-  const hudRect = document.getElementById("hud").getBoundingClientRect();
-  tooltip.style.left = (ev.pageX - hudRect.left + 12) + "px";
-  tooltip.style.top = (ev.pageY - hudRect.top + 12) + "px";
+  if (!tooltip) return;  // guard
+
+  const hud = document.getElementById("hud");
+  if (!hud) return;
+  const hudRect = hud.getBoundingClientRect();
+
+  // Desired position relative to HUD
+  let x = ev.pageX - hudRect.left + 12;
+  let y = ev.pageY - hudRect.top + 12;
+
+  // Clamp horizontally so tooltip stays inside HUD width
+  const tooltipWidth = tooltip.offsetWidth || 200; // fallback if not measured yet
+  const maxX = hudRect.width - tooltipWidth - 8;
+  if (x > maxX) x = Math.max(8, maxX);
+  if (x < 8) x = 8;
+
+  tooltip.style.left = x + "px";
+  tooltip.style.top  = y + "px";
 });
 
+
 document.body.addEventListener("mouseout", () => {
-  // cancel pending tooltip or hide existing one
+  if (!tooltip) return;  // guard
   clearTimeout(tooltipTimer);
-  tooltip.style.opacity = "0";
+  tooltip.style.opacity  = "0";
   tooltip.style.transform = "translateY(4px)";
 });

--- a/frontend/src/renderer/style.css
+++ b/frontend/src/renderer/style.css
@@ -18,6 +18,7 @@ html, body {
   margin: 0;
   padding: 0;
   background: transparent;
+  overflow: hidden;
   height: 100%;
 }
 
@@ -30,7 +31,7 @@ body { -webkit-app-region: drag; }
 .hud {
   overflow: visible;
   position: relative;
-  z-index: 10;
+  z-index: 0;
   -webkit-app-region: drag;
   user-select: none;
   display: flex;
@@ -44,7 +45,6 @@ body { -webkit-app-region: drag; }
   -webkit-backdrop-filter: blur(16px) saturate(180%);
   font: 14px/1 Segoe UI, system-ui, -apple-system, Arial, sans-serif;
   border-radius: 24px;
-  isolation: isolate;
 }
 
 .hud > * { flex: 0 0 auto; }   /* default: fixed-size siblings */
@@ -72,9 +72,10 @@ body { -webkit-app-region: drag; }
   padding: 2px 8px;
   border: 1.5px solid #AAA;
   border-radius: 10px;
-
-  /* lock width to fit 5 chars comfortably */
-  width: 96px; min-width: 96px; max-width: 96px; flex: 0 0 96px;
+  width: 96px;
+  min-width: 96px;
+  max-width: 96px;
+  flex: 0 0 96px;
 
   height: 24px;
   line-height: 16px;
@@ -89,7 +90,13 @@ body { -webkit-app-region: drag; }
 #ticker-measure { display: none; }
 
 /* Sections */
-.sec { white-space: nowrap; position: relative; display: inline-block; -webkit-app-region: no-drag; pointer-events: auto; }
+.sec {
+  white-space: nowrap;
+  position: relative;
+  display: inline-block;
+  -webkit-app-region: no-drag;
+  pointer-events: auto;
+}
 .num { font-weight: 600; }
 .muted { color: var(--muted); font-weight: 500; }
 .sep { color: #867e98; opacity: .9; position: relative; }
@@ -102,11 +109,22 @@ body { -webkit-app-region: drag; }
 
 .conf  { position: relative; display: inline-flex; align-items: center; }
 .conf .bar {
-  position: absolute; left: 0; top: 50%; transform: translateY(-50%);
-  height: 10px; max-width: 32px; width: 0;
-  background: rgba(151,110,254,.35); border-radius: 3px; z-index: 0;
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  height: 10px;
+  max-width: 32px;
+  width: 0;
+  background: rgba(151,110,254,.35);
+  border-radius: 3px;
+  z-index: 0;
 }
-.conf span:last-child { position: relative; padding-left: 4px; z-index: 1; }
+.conf span:last-child {
+  position: relative;
+  padding-left: 4px;
+  z-index: 1;
+}
 
 /* ---------- One-liner grows/shrinks; ellipsis ---------- */
 .oneliner {
@@ -135,19 +153,6 @@ a[href] {
   border-bottom: 1px dotted rgba(201,201,255,0.35);
   cursor: pointer;
 }
-.oneliner a:hover,
-.src-link:hover {
-  color: #b3b8ff;
-  border-bottom: 1px solid rgba(201,201,255,0.6);
-  text-shadow: 0 0 4px rgba(180,180,255,0.4);
-}
-
-#ticker:hover {
-  border-color: #c9c9ff;
-  background-color: #363654;
-  transition: all 0.15s ease;
-}
-
 
 .pos { color: var(--pos); }
 .neg { color: var(--neg); }
@@ -155,39 +160,50 @@ a[href] {
 
 /* HUD info visibility */
 #hud-info {
-  display: flex; flex-direction: row; justify-content: flex-start;
-  visibility: hidden; flex-wrap: nowrap; opacity: 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  visibility: hidden;
+  flex-wrap: nowrap;
+  opacity: 0;
   transition: opacity 0.4s ease, visibility 0s linear 0.4s;
-  align-items: center; gap: 8px; height: var(--h);
+  align-items: center;
+  gap: 8px;
+  height: var(--h);
 }
-#hud-info.active { opacity: 1; transition-delay: 0s; visibility: visible; }
-#hud-info.hidden { opacity: 0; pointer-events: none; visibility: hidden; }
+#hud-info.active {
+  opacity: 1;
+  transition-delay: 0s;
+  visibility: visible;
+}
+#hud-info.hidden {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
 
 /* Validation */
 .validationPrompt { opacity: 1; transition: opacity 0.4s ease; }
 .validationPrompt.hidden { opacity: 0; pointer-events: none; }
 
 /* ========================================
-   TOOLTIP BOX
+   Global tooltip box (for data-tooltip)
    ======================================== */
-.tooltip-box {
-  position: absolute;
-  z-index: 9999;
-  pointer-events: none;
-  background: rgba(25,25,40,0.95);
-  color: #fff;
-  border-radius: 6px;
-  padding: 6px 8px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.4);
-  opacity: 0;
-  transform: translateY(4px);
-  transition: opacity 0.25s ease, transform 0.25s ease;
-  max-width: 260px;
-  white-space: normal;
-  will-change: transform;
-  backdrop-filter: none;
-}
 
-.tooltip-box strong {
-  color: #a9b7ff;
+.tooltip-box {
+  position: absolute;                /* position relative to .hud */
+  z-index: 9999;
+  top: 100%;                         /* default: just below HUD */
+  left: 0;
+  padding: 4px 8px;
+  background: rgba(18,20,30,0.96);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 1.3;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;                        /* hidden by default */
+  transform: translateY(4px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
 }

--- a/services/context_api/app.py
+++ b/services/context_api/app.py
@@ -1,51 +1,36 @@
+from __future__ import annotations
 from fastapi import FastAPI, HTTPException
-from datetime import datetime, timezone
 from pydantic import BaseModel
+from datetime import datetime, timezone
+from typing import List, Optional, Dict, Any
+
 from .features import build_features_stub, build_features_for
-import logging
 
 app = FastAPI(title="MIDAS Context API", version="v1")
-log = logging.getLogger("context_api")
 
 def ts_utc_now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 @app.get("/healthz")
 def healthz():
-    return {"status": "ok", "service": "context", "version": "v1"}
+    return {"status":"ok","service":"context","version":"v1"}
 
 @app.get("/api/features")
 def features_stub(ticker: str):
-    if not ticker or not ticker.strip():
-        raise HTTPException(status_code=422, detail="ticker is required")
     return {"features": build_features_stub(), "ticker": ticker, "ts": ts_utc_now()}
 
 @app.get("/api/features/v2")
 def features_v2(ticker: str):
-    if not ticker or not ticker.strip():
-        raise HTTPException(status_code=422, detail="ticker is required")
     try:
-        bundle = build_features_for(ticker)  # {"features":..., "top_headline":..., "quote":..., "error":...}
-        resp = {
-            "features": bundle.get("features", {}),
-            "ticker": ticker,
-            "ts": ts_utc_now(),
-        }
-        if bundle.get("top_headline"):
-            resp["top_headline"] = bundle["top_headline"]
-        if bundle.get("quote"):
-            resp["quote"] = bundle["quote"]
-        if bundle.get("error"):
-            resp["error"] = bundle["error"]
-        return resp
+        payload = build_features_for(ticker)
+        payload["ticker"] = ticker
+        payload["ts"] = ts_utc_now()
+        return payload
     except Exception as e:
-        log.exception("features_v2 failed for %s", ticker)
-        return {
-            "features": build_features_stub(),
-            "ticker": ticker,
-            "ts": ts_utc_now(),
-            "error": str(e),
-        }
+        # degrade gracefully
+        return {"features": build_features_stub(), "ticker": ticker, "ts": ts_utc_now(), "error": str(e)}
+
+# ------- One-liner builder -------
 
 class OneLinerIn(BaseModel):
     class_: str
@@ -53,18 +38,47 @@ class OneLinerIn(BaseModel):
     title: str = ""
     publisher: str = ""
     url: str = ""
+    refs: Optional[List[Optional[Dict[str, str]]]] = None  # up to 3 refs; may include None
+
+def _strategy_phrase(cls: str) -> str:
+    m = {
+        "IRON_CONDOR": "Range-bound, IV watch",
+        "DEBIT_CALL": "Bullish, defined risk",
+        "DEBIT_PUT": "Bearish, defined risk",
+        "COVERED_CALL": "Income; upside capped",
+        "NO_ACTION": "Signal unclear",
+    }
+    return m.get(cls, "Review setup")
+
+def _build_index_suffix(refs: Optional[List[Optional[Dict[str,str]]]]) -> tuple[str, List[Dict[str, Any]]]:
+    """Return text like '([1][2][3])' and an array mapping of numbers to urls."""
+    if not refs:
+        return "", []
+    nums = []
+    shown = []
+    n = 1
+    for slot in refs[:3]:
+        if slot and slot.get("url"):
+            nums.append(f"[{n}]")
+            shown.append({"n": n, "url": slot.get("url")})
+            n += 1
+    if not nums:
+        return "", []
+    return f" ({''.join(nums)})", shown
 
 @app.post("/api/one_liner")
 def one_liner(x: OneLinerIn):
-    risk = {
-        "IRON_CONDOR": "range-bound, IV watch",
-        "DEBIT_CALL": "bullish, defined risk",
-        "DEBIT_PUT": "bearish, defined risk",
-        "COVERED_CALL": "income, upside capped",
-        "NO_ACTION": "signal unclear",
-    }.get(x.class_, "review setup")
-    msg = (
-        f"{x.class_}: {risk}. Conf {x.confidence:.0%}. "
-        f"Source: {x.publisher} — {x.title[:80]} {x.url}"
-    )
-    return {"text": msg[:180]}
+    # prefix: strategy + confidence
+    conf_pct = int(round((x.confidence or 0.0) * 100))
+    phrase = _strategy_phrase(x.class_)
+    base = f"{phrase}. Source: {(x.publisher or 'News')} —".strip()
+
+    # indices
+    suffix, refs_numbers = _build_index_suffix(x.refs)
+
+    # Compose and clamp to 180 chars
+    text = f"{base}{suffix}"
+    if len(text) > 180:
+        text = (text[:177] + "…")
+
+    return {"text": text, "refs_numbers": refs_numbers}


### PR DESCRIPTION
## Summary

This PR contains the working Prototype 2 HUD implementation as demoed:

- **Backend pipeline**
  - Sentiment API (`services/sentiment_api/app.py`) using FinBERT (with lexicon fallback) + TTL caching.
  - Context API (`services/context_api/features.py`) now:
    - Pulls Tiingo + Finnhub data,
    - Merges Finnhub + Yahoo headlines into `refs` (3 max, de-duplicated),
    - Computes live features (r_1m, r_5m, rv20, mins_since_news, earnings_soon, liquidity_flag),
    - Calls Sentiment API over top headlines → `sent_mean`, `sent_std`.
  - Gateway API (`services/gateway_api/app.py`) wires `/api/run` to:
    - Call `/api/features/v2`,
    - Call recommender `/api/recommend`,
    - Call context `/api/one_liner`,
    - Return `one_liner.text` + `one_liner.refs_numbers`.

- **HUD / frontend (`frontend/src/renderer`)**
  - Renders a one-line summary from `one_liner.text`, then indices `([1], [2], [3])` mapped from `refs_numbers`.
  - Adds rich tooltips for:
    - 1m / 5m returns (“what / why”),
    - SMA20 arrow,
    - Sentiment + σ (FinBERT-style news tone + disagreement),
    - Strategy class + calibrated confidence,
    - One-line summary and its source refs,
    - Refresh Age (live data staleness counter).
  - Ensures tooltips stay within the HUD width (clamped left/right) and appear just below the bar.
  - Fixes CSP to allow `connect-src http://127.0.0.1:8015` and uses `GATEWAY_URL=http://127.0.0.1:8015`.

- **Notes**
  - This branch represents the working code on my laptop that was used for the Prototype 2 demo.
  - It supersedes the earlier non-working branch that included the pjoys merge; this branch should be used for review/demo.
